### PR TITLE
updated div class selectors

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,8 +9,8 @@ const EVENT_PANEL_SELECTOR = ".pPTZAe";
 const OPTIONS_BUTTON_SELECTOR = '.d29e1c';
 const SAVE_BUTTON_SELECTOR = '[jsname="x8hlje"]';
 const DUPLICATE_BUTTON_SELECTOR = '[jsname="lbYRR"]';
-const MINI_CALENDAR_DAY_SELECTOR = ".W0m3G";
-const MINI_CALENDAR_CURRENT_DAY_SELECTOR = ".folmac";
+const MINI_CALENDAR_DAY_SELECTOR = ".pWJCO";
+const MINI_CALENDAR_CURRENT_DAY_SELECTOR = ".p6vobf";
 const INTERVAL_DELAY = 50;
 /** ======================================== */
 


### PR DESCRIPTION
### Description
As reported in #22 the extension has mostly stopped working in google-chrome and chromium. More precisely, the shortcut (alt+click) and the event popup "duplicate" button do not work at all.
This is because class selectors in the google calendar webpage have changed, which makes the extension [app.js crash at line 128](https://github.com/fabiosangregorio/google-calendar-quick-duplicate/blob/master/app.js#L128) (found in console). 

Updating the `MINI_CALENDAR_DAY_SELECTOR` and `MINI_CALENDAR_CURRENT_DAY_SELECTOR` to new class strings found in the website code resolves the problems.

### References
- fixes #22 

### Testing
Tested in Chromium `112.0.5615.49` and Chrome `114.0.5735.198`

- alt+click => correctly duplicates event
- duplicate button in event popup => correctly duplicates event
- (optional: check console for no error messages for this exception)

